### PR TITLE
Platforms: minimally document where to find us

### DIFF
--- a/platforms.md
+++ b/platforms.md
@@ -1,0 +1,11 @@
+# ROOST Community Platforms
+
+ROOST and the community interact across multiple platforms. These are the officially-recognized platforms and spaces that we currently use:
+
+1. [@roostorg](https://github.com/roostorg) on GitHub
+2. [ROOST (Robust Open Online Safety Tools)](https://discord.gg/5Csqnw2FSQ) Discord server
+
+In addition, ROOST maintains a social media presence on these platforms:
+
+1. [@roost.tools](https://bsky.app/profile/roost.tools) on Bluesky
+2. [company/roost-tools](https://www.linkedin.com/company/roost-tools/) on LinkedIn


### PR DESCRIPTION
This might be a little redundant with the website (and if we decide it is, we can remove it!), but I think it's handy to link to this stuff in the community-wide docs at least.