### PR TITLE
README: add code of conduct and contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ Documentation and policies for the ROOST organization and open source community.
 - Browse the docs in this repo
 - [File an issue](https://github.com/roostorg/community/issues) to suggest ideas or tasks
 - [Join our Discord](https://discord.gg/5Csqnw2FSQ) to chat with the team, T&S professionals, open source builders, and other members of the community
+
+By participating in our community, you agree to follow the [code of conduct](https://github.com/roostorg/.github/blob/main/CODE_OF_CONDUCT.md) and [contribution guidelines](https://github.com/roostorg/.github/blob/main/CONTRIBUTING.md). Please give them a read to familiarize yourself with them if you haven't already (or if it's been a while).


### PR DESCRIPTION
I know these show in the web UI on GitHub, but they're a bit harder to find on mobile (and if we turn this into a docs site) so it makes sense to include them right here.