### PR TITLE
README: link to org-wide discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,6 @@ Documentation and policies for the ROOST organization and open source community.
 - Browse the docs in this repo
 - [File an issue](https://github.com/roostorg/community/issues) to suggest ideas or tasks
 - [Join our Discord](https://discord.gg/5Csqnw2FSQ) to chat with the team, T&S professionals, open source builders, and other members of the community
+- [Start or join a discussion](https://github.com/orgs/roostorg/discussions) on the ROOST org
 
 By participating in our community, you agree to follow the [code of conduct](https://github.com/roostorg/.github/blob/main/CODE_OF_CONDUCT.md) and [contribution guidelines](https://github.com/roostorg/.github/blob/main/CONTRIBUTING.md). Please give them a read to familiarize yourself with them if you haven't already (or if it's been a while).


### PR DESCRIPTION
To reduce the surface area of discussions, it makes more sense to use org-wide discussions and keep this repo as docs and issue tracking.

I've disabled the wiki and discussions here, and pointed people explicitly to the org-wide discussions