### PR TITLE
Workflows: update mdBook version to latest

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -29,7 +29,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      MDBOOK_VERSION: 0.4.36
+      MDBOOK_VERSION: 0.5.2
     steps:
       - uses: actions/checkout@v4
       - name: Install mdBook


### PR DESCRIPTION
Apparently GitHub's action had an old version 🙃