### PR TITLE
Nit: more concise titles for platforms and roles pages

### DIFF
--- a/platforms.md
+++ b/platforms.md
@@ -1,4 +1,4 @@
-# ROOST Community Platforms
+# Platforms
 
 ROOST and the community interact across multiple platforms. These are the officially-recognized platforms and spaces that we currently use:
 

--- a/roles.md
+++ b/roles.md
@@ -1,4 +1,4 @@
-# ROOST Project Roles
+# Project Roles
 
 We aim to have clearly-defined roles and expectations for each open source project that ROOST hosts. This is not intended to be overly prescriptive, but should make it clear what ROOST does, what a maintainer does, etc. while leaving room to grow and adapt over time.
 


### PR DESCRIPTION
Something that annoyed me when working on the docs site; these don't need to repeat "ROOST" everywhere. :)