### PR TITLE
require human approval for any dependency change

### DIFF
--- a/software-development-practices/agents.md
+++ b/software-development-practices/agents.md
@@ -66,4 +66,4 @@ Agents must stop and get explicit human approval before:
 
 - Changing license headers, copyright notices, or any legal text
 - Modifying release, signing, or deploy workflows (CI/CD pipeline files, Makefiles, etc.)
-- Adding a new dependency — confirm its license is compatible first
+- Adding, removing, or upgrading any library or package (including transitive dependencies) — confirm licenses are compatible


### PR DESCRIPTION
Broadens the human-approval rule in agents.md to cover addition, removals and version upgrades of packages. 