### PR TITLE
theme: improved light style, contrasty dark style

### DIFF
--- a/theme/css/roost.css
+++ b/theme/css/roost.css
@@ -2,7 +2,7 @@
 
 :root {
   --roost-gray: rgb(187, 193, 190);
-  --roost-dark: hsl(80, 22%, 13%);
+  --roost-charcoal: hsl(80, 22%, 13%);
   --roost-yellow: rgb(238, 238, 0);
   --roost-peach: rgb(247, 187, 128);
   --roost-muddy: rgb(229, 217, 136);
@@ -12,27 +12,24 @@
 
 .light, html:not(.js), .navy {
   --bg: rgb(245, 245, 245);
-  --fg: var(--roost-dark);
+  --fg: var(--roost-charcoal);
 
-  /* --sidebar-bg: var(--roost-dark); */
-  --sidebar-bg: oklch(from var(--bg) calc(l * 0.97) c h);
-  --sidebar-fg: var(--fg);
+  --sidebar-bg: var(--roost-charcoal);
+  --sidebar-fg: rgba(255 255 255 / 0.9);
   --sidebar-non-existant: #5c6773;
-  --sidebar-active: oklch(from var(--roost-muddy) calc(l * 0.5) c h);
+  --sidebar-active: var(--roost-muddy);
   --sidebar-spacer: var(--roost-muddy);
   --sidebar-header-border-color: oklch(from var(--roost-yellow) calc(l * 0.95) c h);
+
+  --icons: white;
+  --icons-hover: var(--roost-yellow);
 
   --links: inherit;
 }
 
 .navy {
-  --bg: var(--roost-dark);
-  --fg: rgba(255, 255, 255, 0.9);
-
-  --sidebar-active: var(--roost-muddy);
-
-  --icons: white;
-  --icons-hover: var(--roost-yellow);
+  --bg: color-mix(var(--roost-charcoal) 90%, black);
+  --fg: rgba(255 255 255 / 0.9);
 }
 
 #mdbook-theme-toggle {
@@ -40,7 +37,9 @@
 }
 
 #mdbook-menu-bar {
-  background-color: oklch(from var(--bg) calc(l * 1.2) c h);
+  background-color: var(--roost-charcoal);
+  border: none;
+  box-shadow: 0 0.25em 1em rgba(0 0 0 / 0.25);
 }
 
 #mdbook-sidebar-resize-handle {
@@ -50,4 +49,14 @@
 .content a {
   font-weight: bold;
   text-decoration: underline;
+}
+
+a:link.mobile-nav-chapters {
+  color: var(--roost-yellow);
+}
+
+.blockquote-tag {
+  background: color-mix(var(--fg) 5%, transparent);
+  border-radius: 0.25em;
+  padding: 1em;
 }


### PR DESCRIPTION
Use the ROOST-style header and sidebar for both light and dark styles. On the dark style, darken the background slightly for better contrast between the page and UI. Also a tiny improvement to blockquote callouts for contrast.

Eventual goal is to use this theme for all project mdbook docs sites, so I spent a little time ensuring it feels more ROOST-branded.

Left old, right new

<img width="4266" height="2399" alt="Screenshot From 2026-06-01 17-23-09" src="https://github.com/user-attachments/assets/801f156f-ea1e-4e0c-a508-0f0e19ce0c8a" />

<img width="4266" height="2399" alt="Screenshot From 2026-06-01 17-23-19" src="https://github.com/user-attachments/assets/7bee791c-fffb-4cf5-97e7-172ee950b946" />