### PR TITLE
meetings: Add notes processing tool

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -10,6 +10,7 @@
 - [Documentation Guidelines](documentation.md)
 - [Meetings](meetings/README.md)
   - [Guidelines](meetings/guidelines.md)
+  - [Notes Tool](meetings/notes/index.md)
 
 ---
 

--- a/book.toml
+++ b/book.toml
@@ -11,6 +11,7 @@ build-dir = "./book"
 additional-css = ["theme/css/roost.css"]
 edit-url-template = "https://github.com/roostorg/community/edit/main/{path}"
 git-repository-url = "https://github.com/roostorg"
+site-url = "/community/"
 
 [output.html.print]
 enable = false

--- a/meetings/notes/index.md
+++ b/meetings/notes/index.md
@@ -1,0 +1,187 @@
+# Process Meeting Notes
+
+Paste Google Docs Markdown export on the left; cleaned Markdown for GitHub Discussions appears on the right.
+
+<style>
+  :root {
+    --content-max-width: 1200px;
+  }
+
+  .nav-chapters {
+    display: none;
+  }
+
+  .notes-tool, .notes-tool * {
+    box-sizing: border-box;
+  }
+
+  .notes-tool {
+    --nt-border: color-mix(var(--fg) 25%, transparent);
+
+    display: flex;
+    flex-direction: column;
+    gap: 2em;
+    width: 100%;
+  }
+
+  .notes-tool details {
+    background-color: color-mix(var(--fg) 5%, transparent);
+    border-radius: 0.5em;
+    border: 1px solid var(--nt-border);
+    flex-shrink: 0;
+    padding: 0.5em;
+  }
+
+  .notes-tool details button {
+    float: right;
+    margin-block-end: 0.5em;
+  }
+
+  .notes-tool summary {
+    align-items: center;
+    cursor: pointer;
+    display: flex;
+    gap: 0.5em;
+    list-style: none;
+    user-select: none;
+  }
+
+  .notes-tool summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .notes-tool summary::before {
+    content: "▶";
+    font-size: 0.8em;
+    transition: transform 150ms;
+  }
+
+  .notes-tool details[open] summary::before {
+    transform: rotate(90deg);
+  }
+
+  .notes-tool textarea {
+    background-color: light-dark(white, rgba(0 0 0 / 0.5));
+    border-radius: 0.25em;
+    border: 1px solid var(--nt-border);
+    font-family: var(--mono-font);
+    line-height: 1.5;
+    min-height: 20em;
+    padding: 0.5em;
+    resize: vertical;
+    width: 100%;
+  }
+
+  .notes-tool main {
+    display: grid;
+    gap: 1em;
+    grid-template-columns: 1fr 1fr;
+    height: 60vh;
+    min-height: 400px;
+    width: 100%;
+  }
+
+  .notes-tool .pane { 
+    display: flex; 
+    flex-direction: column; 
+    gap: 0.5em;
+  }
+
+  .notes-tool .pane-header { 
+    align-items: center; 
+    display: flex; 
+    gap: 1em; 
+  }
+
+  .notes-tool .pane-header h2 {
+    margin: 0;
+  }
+
+  .notes-tool .pane textarea {
+    flex: 1;
+    resize: none;
+  }
+</style>
+
+<div class="notes-tool">
+  <details>
+    <summary>Name map</summary>
+    <p>JSON mapping emails and display names to GitHub usernames. Loaded from <a href="name-map.json">name-map.json</a> on first visit; edits are saved in your browser.</p>
+    <button id="reload-map-btn">Reset</button>
+    <textarea id="name-map-ta" rows="6" spellcheck="false"></textarea>
+  </details>
+
+  <main>
+    <div class="pane">
+      <div class="pane-header"><h2>Input</h2></div>
+      <textarea id="input" spellcheck="false" placeholder="Paste Google Docs Markdown…"></textarea>
+    </div>
+    <div class="pane">
+      <div class="pane-header">
+        <h2>Output</h2>
+        <button id="copy-btn">Copy</button>
+      </div>
+      <textarea id="output" spellcheck="false" placeholder="Markdown for GitHub will output here" readonly></textarea>
+    </div>
+  </main>
+</div>
+
+<script type="module">
+  import { loadNameMap, processNotes } from './transform.js';
+
+  const nameMapTa = document.getElementById('name-map-ta');
+  const inputTa   = document.getElementById('input');
+  const outputTa  = document.getElementById('output');
+  const copyBtn   = document.getElementById('copy-btn');
+  let debounce;
+
+  const saved = localStorage.getItem('roost-name-map');
+  if (saved) {
+    nameMapTa.value = saved;
+    update();
+  } else {
+    fetch('./name-map.json')
+      .then(r => r.text())
+      .then(text => { nameMapTa.value = text; update(); })
+      .catch(() => {});
+  }
+
+  function buildMaps(json) {
+    try { return loadNameMap(JSON.parse(json)); }
+    catch (e) { return { emailToGithub: {}, nameToGithub: {} }; }
+  }
+
+  function update() {
+    clearTimeout(debounce);
+    debounce = setTimeout(() => {
+      const { emailToGithub, nameToGithub } = buildMaps(nameMapTa.value);
+      outputTa.value = processNotes(inputTa.value, emailToGithub, nameToGithub);
+    }, 150);
+  }
+
+  inputTa.addEventListener('input', update);
+  nameMapTa.addEventListener('input', () => {
+    localStorage.setItem('roost-name-map', nameMapTa.value);
+    update();
+  });
+
+  document.getElementById('reload-map-btn').addEventListener('click', () => {
+    fetch('./name-map.json')
+      .then(r => r.text())
+      .then(text => {
+        nameMapTa.value = text;
+        localStorage.setItem('roost-name-map', text);
+        update();
+      });
+  });
+
+  copyBtn.addEventListener('click', () => {
+    navigator.clipboard.writeText(outputTa.value);
+    copyBtn.textContent = 'Copied!';
+    copyBtn.classList.add('success');
+    setTimeout(() => {
+      copyBtn.textContent = 'Copy';
+      copyBtn.classList.remove('success');
+    }, 2000);
+  });
+</script>

--- a/meetings/notes/name-map.json
+++ b/meetings/notes/name-map.json
@@ -1,0 +1,25 @@
+{
+  "people": [
+    {
+      "github": "calebmcquaid",
+      "names": [
+        "Caleb"
+      ]
+    },
+    {
+      "github": "cassidyjames",
+      "emails": ["cassidyjames@roost.tools"],
+      "names": ["Cassidy James Blaede", "Cassidy"]
+    },
+    {
+      "github": "juanmrad",
+      "emails": ["juan@roost.tools"],
+      "names": ["Juan Mrad", "Juan"]
+    },
+    {
+      "github": "julietshen",
+      "emails": ["juliet@roost.tools"],
+      "names": ["Juliet Shen", "Juliet"]
+    }
+  ]
+}

--- a/meetings/notes/process-notes.mjs
+++ b/meetings/notes/process-notes.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+/**
+ * Process ROOST meeting notes from Google Docs Markdown export to GitHub Discussions format.
+ *
+ * Usage:
+ *   node process-notes.mjs notes.md        # from file
+ *   cat notes.md | node process-notes.mjs  # from stdin
+ *
+ * Transformation logic lives in transform.js. Name mapping lives in name-map.json.
+ */
+import { readFileSync, existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { loadNameMap, processNotes } from './transform.js';
+
+const configPath = join(dirname(fileURLToPath(import.meta.url)), 'name-map.json');
+
+let emailToGithub = {}, nameToGithub = {};
+if (existsSync(configPath)) {
+  ({ emailToGithub, nameToGithub } = loadNameMap(JSON.parse(readFileSync(configPath, 'utf8'))));
+} else {
+  process.stderr.write(`Warning: ${configPath} not found; name mapping disabled\n`);
+}
+
+let text;
+if (process.argv[2]) {
+  text = readFileSync(process.argv[2], 'utf8');
+} else {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  text = Buffer.concat(chunks).toString('utf8');
+}
+
+process.stdout.write(processNotes(text, emailToGithub, nameToGithub));

--- a/meetings/notes/transform.js
+++ b/meetings/notes/transform.js
@@ -1,0 +1,68 @@
+/**
+ * Pure transformation logic for processing ROOST meeting notes.
+ * Used by both process-notes.mjs (CLI) and index.html (web app).
+ */
+
+export function loadNameMap(data) {
+  const emailToGithub = {}, nameToGithub = {};
+  for (const person of data.people ?? []) {
+    for (const email of person.emails ?? [])
+      emailToGithub[email.toLowerCase()] = person.github;
+    for (const name of person.names ?? [])
+      nameToGithub[name.toLowerCase()] = person.github;
+  }
+  return { emailToGithub, nameToGithub };
+}
+
+function escapeRegex(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function processNotes(text, emailToGithub, nameToGithub) {
+  let inActions = false;
+  const lines = text.split('\n').map(line => {
+    line = line.replace(/\s+$/, '');
+
+    if (/^## Actions\b/.test(line)) inActions = true;
+    else if (/^## /.test(line)) inActions = false;
+
+    // Issue/PR links: [\#NNN](https://github.com/ORG/REPO/issues/NNN) → #NNN
+    line = line.replace(
+      /\[\\?#(\d+)\]\(https:\/\/github\.com\/[^)]+\/(?:issues|pull)\/\d+\/?\)/g,
+      '#$1'
+    );
+
+    // [Name](mailto:email) → @github-username
+    line = line.replace(/\[([^\]]+)\]\(mailto:([^)]+)\)/g, (match, _name, email) => {
+      const github = emailToGithub[email.toLowerCase()];
+      return github ? `@${github}` : match;
+    });
+
+    // Unescape Google Docs artifacts: \! \( \) \[ \]
+    line = line.replace(/\\([!()\[\]])/g, '$1');
+
+    // * bullets → - bullets (preserving indentation)
+    line = line.replace(/^(\s*)\* /g, '$1- ');
+
+    // Actions section: ensure all list items are checklists
+    if (inActions) line = line.replace(/^(\s*)-\s+(?!\[)/, '$1- [ ] ');
+
+    return line;
+  });
+
+  let result = lines.join('\n');
+
+  // Replace bare names → @-mentions, longest names first to avoid partial matches
+  for (const [name, github] of Object.entries(nameToGithub)
+      .sort(([a], [b]) => b.length - a.length)) {
+    result = result.replace(
+      new RegExp('(?<![/@\\w])' + escapeRegex(name) + '(?!\\w)', 'gi'),
+      `@${github}`
+    );
+  }
+
+  result = result.replace(/^\s*[-*]\s*$/gm, '');  // remove blank bullet lines
+  result = result.replace(/\n{3,}/g, '\n\n');      // collapse 3+ blank lines
+
+  return result.trim() + '\n';
+}

--- a/meetings/tools/index.md
+++ b/meetings/tools/index.md
@@ -1,0 +1,1 @@
+# Process Meeting Notes

--- a/theme/css/roost.css
+++ b/theme/css/roost.css
@@ -2,7 +2,7 @@
 
 :root {
   --roost-gray: rgb(187, 193, 190);
-  --roost-dark: hsl(80, 22%, 13%);
+  --roost-charcoal: hsl(80, 22%, 13%);
   --roost-yellow: rgb(238, 238, 0);
   --roost-peach: rgb(247, 187, 128);
   --roost-muddy: rgb(229, 217, 136);
@@ -12,27 +12,24 @@
 
 .light, html:not(.js), .navy {
   --bg: rgb(245, 245, 245);
-  --fg: var(--roost-dark);
+  --fg: var(--roost-charcoal);
 
-  /* --sidebar-bg: var(--roost-dark); */
-  --sidebar-bg: oklch(from var(--bg) calc(l * 0.97) c h);
-  --sidebar-fg: var(--fg);
+  --sidebar-bg: var(--roost-charcoal);
+  --sidebar-fg: rgba(255 255 255 / 0.9);
   --sidebar-non-existant: #5c6773;
-  --sidebar-active: oklch(from var(--roost-muddy) calc(l * 0.5) c h);
+  --sidebar-active: var(--roost-muddy);
   --sidebar-spacer: var(--roost-muddy);
   --sidebar-header-border-color: oklch(from var(--roost-yellow) calc(l * 0.95) c h);
+
+  --icons: white;
+  --icons-hover: var(--roost-yellow);
 
   --links: inherit;
 }
 
 .navy {
-  --bg: var(--roost-dark);
-  --fg: rgba(255, 255, 255, 0.9);
-
-  --sidebar-active: var(--roost-muddy);
-
-  --icons: white;
-  --icons-hover: var(--roost-yellow);
+  --bg: color-mix(var(--roost-charcoal) 90%, black);
+  --fg: rgba(255 255 255 / 0.9);
 }
 
 #mdbook-theme-toggle {
@@ -40,7 +37,9 @@
 }
 
 #mdbook-menu-bar {
-  background-color: oklch(from var(--bg) calc(l * 1.2) c h);
+  background-color: var(--roost-charcoal);
+  border: none;
+  box-shadow: 0 0.25em 1em rgba(0 0 0 / 0.25);
 }
 
 #mdbook-sidebar-resize-handle {
@@ -50,4 +49,14 @@
 .content a {
   font-weight: bold;
   text-decoration: underline;
+}
+
+a:link.mobile-nav-chapters {
+  color: var(--roost-yellow);
+}
+
+.blockquote-tag {
+  background: color-mix(var(--fg) 5%, transparent);
+  border-radius: 0.25em;
+  padding: 1em;
 }

--- a/theme/css/roost.css
+++ b/theme/css/roost.css
@@ -11,7 +11,7 @@
 }
 
 .light, html:not(.js), .navy {
-  --bg: rgb(245, 245, 245);
+  --bg: rgb(250 250 250);
   --fg: var(--roost-charcoal);
 
   --sidebar-bg: var(--roost-charcoal);
@@ -60,7 +60,7 @@ a:link.mobile-nav-chapters {
 }
 
 .blockquote-tag {
-  background: color-mix(var(--fg) 5%, transparent);
+  background: color-mix(var(--fg) 3%, transparent);
   border-radius: 0.25em;
   padding: 1em;
 }

--- a/theme/css/roost.css
+++ b/theme/css/roost.css
@@ -46,6 +46,10 @@
   background-color: var(--sidebar-bg);
 }
 
+.content {
+  padding: 2em 1em 1em;
+}
+
 .content a {
   font-weight: bold;
   text-decoration: underline;


### PR DESCRIPTION
This is the most annoying part of sharing notes for each working group/office hours call, so I made a little static JavaScript tool. Input Google Docs Markdown (with all of its excess cruft) and output cleaned up Markdown for GitHub, e.g. to paste notes into Discussion comments.

- Converts known names to GitHub @-mentions
- Cleans up issue/PR links

You can use it from the repo from the cli e.g. with `node process-notes.mjs notes.md`, but the simplest is to just use the static web front-end.

Light | Dark
----- | ----
<img width="3200" height="2000" alt="image" src="https://github.com/user-attachments/assets/9765cd2c-d620-408d-839c-942583e06364" /> | <img width="3199" height="1999" alt="image" src="https://github.com/user-attachments/assets/36d34d88-b2ac-496d-8f9e-45fc8129b696" />
